### PR TITLE
Added Restart=always to service file

### DIFF
--- a/unifibackup.service
+++ b/unifibackup.service
@@ -5,6 +5,7 @@ After=network.target
 
 [Service]
 User=unifi
+Restart=always
 
 # specify --prefix to override the bucket prefix from "unifi/"
 ExecStart=/usr/local/bin/unifibackup --bucket <changeme>

--- a/unifibackup.service
+++ b/unifibackup.service
@@ -4,7 +4,6 @@ Documentation=https://github.com/gebn/unifibackup/blob/master/README.md
 After=network.target
 
 [Service]
-Type=simple
 User=unifi
 
 # specify --prefix to override the bucket prefix from "unifi/"


### PR DESCRIPTION
I would recommend adding Restart=always to the service file as I had an issue with the daemon running and reporting failed state because the actual unifibackup process was gone long ago and that kinda misses the point of having a systemd service